### PR TITLE
HMT-91/Fix delete button on admin create food even tpage

### DIFF
--- a/amplify/data/resource.ts
+++ b/amplify/data/resource.ts
@@ -79,7 +79,7 @@ const schema = a
         attended: a.hasMany("UserFoodEventAttendance", "foodEventId"),
       })
       .authorization((allow) => [
-        allow.group("Admin").to(["create"]),
+        allow.group("Admin").to(["create", "delete"]),
         allow.authenticated().to(["read"]),
       ]),
     Team: a


### PR DESCRIPTION
Changed authorization rules so admins can delete food events allowing the delete button to work on the page.