### PR TITLE
fix homepage text cut out and optimize hackathon countdown

### DIFF
--- a/src/app/participant/page.tsx
+++ b/src/app/participant/page.tsx
@@ -6,7 +6,8 @@ import Greetings from "@/components/Dashboard/Greetings";
 import ImportantInformation from "@/components/Dashboard/ImportantInformation";
 import JudgingInfo from "@/components/Dashboard/JudgingInfo";
 import NextMealScheduled from "@/components/Dashboard/NextMealScheduled";
-import SubmissionDueClock from "@/components/Dashboard/SubmissionDueClock";
+import SubmissionDue from "@/components/Dashboard/SubmissionDue";
+import { SuspenseWrapper } from "@/components/SuspenseWrapper";
 
 export const metadata: Metadata = {
   title: "Hack the Change - Participant",
@@ -36,7 +37,9 @@ export default function page() {
         </div>
         <div className="flex flex-col gap-4 md:col-span-2">
           <ImportantInformation />
-          <SubmissionDueClock />
+          <SuspenseWrapper>
+            <SubmissionDue />
+          </SuspenseWrapper>
         </div>
       </div>
     </div>

--- a/src/components/Dashboard/SubmissionDue.tsx
+++ b/src/components/Dashboard/SubmissionDue.tsx
@@ -1,0 +1,17 @@
+import { fetchContent } from "@/app/actions";
+import type { HackathonDetails } from "@/app/contentfulTypes";
+
+import SubmissionDueClock from "./SubmissionDueClock";
+
+export default async function SubmissionDue() {
+  const hackathonDetails = (
+    (await fetchContent("hackathonDetails")) as unknown as HackathonDetails[]
+  )[0];
+  // submisssionTime is the eventDate + 24 hours
+  const eventDate = new Date(hackathonDetails.fields.eventDate);
+  const submissionTime = new Date(
+    eventDate.setTime(eventDate.getTime() + 24 * 60 * 60 * 1000),
+  );
+
+  return <SubmissionDueClock submissionTime={submissionTime} />;
+}

--- a/src/components/Dashboard/SubmissionDueClock.tsx
+++ b/src/components/Dashboard/SubmissionDueClock.tsx
@@ -1,36 +1,55 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+
+import { hackathonTimeRemaining } from "@/utils/date-utils";
 
 import CountdownTimer from "../LandingPage/CountdownTimer";
-import { calculateDateDifference } from "../LandingPage/HeroSection";
 import Card from "./Card";
 
-export default function SubmissionDueClock() {
-  const eventDate = 1731394799; //UNIX Time stamp: Nov 10, 2024
-  const [hour, setHour] = useState(0);
-  const [minute, setMinute] = useState(0);
+export default function SubmissionDueClock({
+  submissionTime,
+}: {
+  submissionTime: Date;
+}) {
+  const [currentTime, setCurrentTime] = useState(new Date());
+  const hackathonIsOver = useMemo(() => {
+    return currentTime >= submissionTime;
+  }, [currentTime, submissionTime]);
   useEffect(() => {
-    const intervalID = setInterval(() => {
-      const { d, h, m } = calculateDateDifference(new Date(eventDate * 1000));
-      setHour(h + 24 * d);
-      setMinute(m);
+    if (hackathonIsOver) return;
+    const interval = setInterval(() => {
+      setCurrentTime(new Date());
     }, 1000);
-    return () => clearInterval(intervalID);
-  }, []);
+    return () => clearInterval(interval);
+  }, [currentTime, submissionTime]);
+  const { hours, minutes } = useMemo(() => {
+    return hackathonTimeRemaining(submissionTime, currentTime);
+  }, [currentTime, submissionTime]);
+
+  if (hackathonIsOver) {
+    return (
+      <Card className="flex-1 gap-4">
+        <div className="text-2xl font-bold">
+          Deadline for submission has passed! <br />
+          Thank you for participating!
+        </div>
+      </Card>
+    );
+  }
   return (
     <Card className="flex-1 gap-4">
       <div className="font-extrabold italic">Submission Due In...</div>
       <div className="flex flex-row gap-4">
         <CountdownTimer
           name={"Hours"}
-          value={hour}
-          className="bg-emerald-500"
+          value={hours}
+          className="w-52 bg-emerald-500 md:w-52  lg:w-52"
         />
         <CountdownTimer
           name={"Minutes"}
-          value={minute}
-          className="bg-emerald-500"
+          value={minutes}
+          className="w-52 bg-emerald-500 md:w-52 lg:w-52"
         />
       </div>
     </Card>

--- a/src/components/HackathonClock.tsx
+++ b/src/components/HackathonClock.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { useEffect, useMemo, useState } from "react";
+
+import { calculateDateDifference } from "@/utils/date-utils";
+
+const CountdownTimer = dynamic(() => import("./LandingPage/CountdownTimer"), {
+  ssr: false,
+  loading: () => (
+    <div className="aspect-square w-24 rounded-lg bg-awesome-purple p-4  sm:p-8 md:w-36" />
+  ),
+});
+const HACKTIME_HEADER_STYLE = {
+  textShadow: `
+		-2px -2px 0 #fff, 
+		2px -2px 0 #fff, 
+		-2px 2px 0 #fff, 
+		2px 2px 0 #fff,
+		-2px -2px 0 #fff,
+		2px -2px 0 #fff,
+		-2px 2px 0 #fff,
+		2px 2px 0 #fff
+	`,
+};
+
+export default function HackathonClock(props: {
+  eventName: string;
+  eventDate: Date;
+}) {
+  const { eventName, eventDate } = props;
+  const [currentTime, setCurrentTime] = useState(new Date());
+  useEffect(() => {
+    if (isHackathonTime) return;
+    const interval = setInterval(() => {
+      setCurrentTime(new Date());
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [currentTime, eventDate]);
+  const isHackathonTime = useMemo(() => {
+    return currentTime >= eventDate;
+  }, [currentTime, eventDate]);
+
+  const timeRemaining = useMemo(() => {
+    return calculateDateDifference(eventDate, currentTime);
+  }, [currentTime, eventDate]);
+  const eventYear = eventDate.getFullYear();
+  if (isHackathonTime) {
+    return (
+      <h1
+        className="flex-wrap pt-14 text-4xl font-black text-awesomer-purple drop-shadow-lg md:pt-20 md:text-center md:text-5xl lg:pt-32"
+        style={HACKTIME_HEADER_STYLE}
+      >
+        {eventName} {eventYear}
+        <br />
+        has begun!
+      </h1>
+    );
+  }
+
+  return (
+    <>
+      <h1 className="pt-10 text-center text-2xl font-bold text-awesomer-purple">
+        {eventName} begins in ...
+      </h1>
+      <div
+        className={
+          "my-12 flex max-w-screen-md items-center justify-center space-x-3"
+        }
+      >
+        <CountdownTimer name="Days" value={timeRemaining.days} />
+        <CountdownTimer name="Hours" value={timeRemaining.hours} />
+        <CountdownTimer name="Minutes" value={timeRemaining.minutes} />
+        <CountdownTimer name="Seconds" value={timeRemaining.seconds} />
+      </div>
+    </>
+  );
+}

--- a/src/components/LandingPage/AboutEventTile.tsx
+++ b/src/components/LandingPage/AboutEventTile.tsx
@@ -6,7 +6,7 @@ import type { HackathonDetails } from "@/app/contentfulTypes";
 
 const EVENT_DETAILS_SECTION_STYLES = "flex flex-col items-center bg-white";
 const EVENT_DETAILS_CONTENT_STYLES =
-  "bg-pastel-pink border-4 border-dark-pink rounded-3xl mb-20 mt-12 md:flex md:justify-center md:max-w-[1100px] md:shadow-[15px_15px_0px_0px_#FF4D6F]";
+  "bg-pastel-pink border-4 border-dark-pink rounded-3xl my-4 lg:my-8 flex md:flex md:justify-center md:max-w-[1100px] md:shadow-[15px_15px_0px_0px_#FF4D6F]";
 const EVENT_IMAGE_CONTAINER_STYLES =
   "bg-blackish rounded-t-20 border-b-4 border-dark-pink w-72 h-64 md:rounded-tr-none md:rounded-l-3xl md:border-b-0 md:border-r-4 md:h-[370px] md:w-[40vw]";
 const EVENT_IMAGE_STYLES =

--- a/src/components/LandingPage/CountdownTimer.tsx
+++ b/src/components/LandingPage/CountdownTimer.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { useEffect, useState } from "react";
 import { twMerge } from "tailwind-merge";
 
 function CountdownTimer({
@@ -9,10 +12,16 @@ function CountdownTimer({
   value: React.ReactNode;
   className?: string;
 }) {
+  // https://nextjs.org/docs/messages/react-hydration-error#solution-1-using-useeffect-to-run-on-the-client-only
+  const [isClient, setIsClient] = useState(false);
+  useEffect(() => {
+    setIsClient(true);
+  }, []);
+  if (!isClient) return null;
   return (
     <div
       className={twMerge(
-        " relative flex flex-col items-center justify-center rounded-lg bg-awesome-purple p-4 text-white sm:p-8",
+        " relative flex aspect-square w-24 flex-col items-center justify-center rounded-lg bg-awesome-purple p-4 text-white sm:p-8 md:w-36",
         className,
       )}
     >
@@ -34,7 +43,7 @@ function CountdownTimer({
         className={
           "absolute inset-x-0 top-[55%] -translate-y-1/2 border-b-2 border-white/95 "
         }
-      ></div>
+      />
     </div>
   );
 }

--- a/src/components/LandingPage/HackathonInformationContainer.tsx
+++ b/src/components/LandingPage/HackathonInformationContainer.tsx
@@ -5,6 +5,85 @@ import ABOUT_THE_CHALLENGE_IMAGE from "@/images/landingpage/AboutTheChallenge.pn
 import PRIZES_IMAGE from "@/images/landingpage/prizes.png";
 import REQUIREMENTS_IMAGE from "@/images/landingpage/requirements.png";
 
+const CHALLENGE_QUOTES_SVG = "/svgs/landingPage/challenge_quotes.svg";
+const ABOUT_THE_CHALLENGE_BLURB = `Hack the Change aims to inspire students across Canada to leverage technology to enact social change. We’re looking for creative and innovative solutions to existing problems, with the goal of coding a better tomorrow.`;
+const ABOUT_THE_CHALLENGE_TITLE = (
+  <div className="flex flex-row flex-nowrap text-nowrap">
+    <h1 className="  text-3xl font-semibold">
+      About the
+      <span className=" italic text-fuzzy-peach"> Challenge</span>
+    </h1>
+    <Image
+      src={CHALLENGE_QUOTES_SVG}
+      width={20}
+      height={20}
+      alt="Challenge quotes"
+      className=" mb-4 ml-1 select-none"
+    />
+  </div>
+);
+
+const REQUIREMENTS_QUOTES_SVG = "/svgs/landingPage/requirements_quotes.svg";
+const REQUIREMENTS_BLURB = `Requirements: Open to all Canadian students, at the university, college, or high school level. (Must be an accredited institution)`;
+const REQUIREMENTS_TITLE = (
+  <div className="flex flex-row text-3xl font-semibold italic text-awesomer-purple">
+    <Image
+      src={REQUIREMENTS_QUOTES_SVG}
+      width={20}
+      height={20}
+      alt="Challenge quotes"
+      className=" mr-1 mt-2 select-none"
+    />
+    Requirements
+  </div>
+);
+
+const PRIZES_QUOTES_SVG = "/svgs/landingPage/prizes_quotes.svg";
+const PRIZES_BLURB = `Prizes: 1st place - $5,000 CAD; 2nd place - $3,000; 3rd place - $2,000; All prizes will be split between students and the charities of their choice.`;
+const PRIZES_TITLE = (
+  <div className="flex flex-row text-3xl font-semibold italic text-[#00AA88]">
+    Prizes
+    <Image
+      src={PRIZES_QUOTES_SVG}
+      width={20}
+      height={20}
+      alt="Challenge quotes"
+      className=" ml-1 mt-2 select-none"
+    />
+  </div>
+);
+interface SectionProps {
+  title: React.ReactNode;
+  sectionImage: string | StaticImageData;
+  leftPosition?: boolean;
+  blurb: string;
+  bgColor?: string;
+  fontColor?: string;
+}
+const sectionInfo: SectionProps[] = [
+  {
+    sectionImage: ABOUT_THE_CHALLENGE_IMAGE,
+    blurb: ABOUT_THE_CHALLENGE_BLURB,
+    title: ABOUT_THE_CHALLENGE_TITLE,
+    fontColor: "text-white",
+    bgColor: "bg-awesomer-purple",
+  },
+  {
+    sectionImage: REQUIREMENTS_IMAGE,
+    blurb: REQUIREMENTS_BLURB,
+    title: REQUIREMENTS_TITLE,
+    fontColor: "text-black",
+    bgColor: "bg-zinc-100",
+    leftPosition: true,
+  },
+  {
+    sectionImage: PRIZES_IMAGE,
+    blurb: PRIZES_BLURB,
+    title: PRIZES_TITLE,
+    fontColor: "text-black",
+    bgColor: "bg-fuzzy-peach",
+  },
+];
 function SectionContainer({
   title,
   sectionImage,
@@ -12,14 +91,7 @@ function SectionContainer({
   blurb,
   bgColor,
   fontColor,
-}: {
-  title: React.ReactNode;
-  sectionImage: string | StaticImageData;
-  leftPosition?: boolean;
-  blurb: string;
-  bgColor?: string;
-  fontColor?: string;
-}) {
+}: SectionProps) {
   return (
     <div
       className={twMerge(
@@ -34,7 +106,7 @@ function SectionContainer({
       </div>
       <div
         className={twMerge(
-          "relative box-content hidden aspect-square w-2/3 min-w-48 max-w-96 md:block",
+          "relative box-content hidden aspect-square w-2/3 min-w-48 max-w-96 lg:block",
           leftPosition && "order-first",
         )}
       >
@@ -52,54 +124,6 @@ function SectionContainer({
 }
 
 export default function HackathonInformationContainer() {
-  const CHALLENGE_QUOTES_SVG = "/svgs/landingPage/challenge_quotes.svg";
-  const ABOUT_THE_CHALLENGE_BLURB = `Hack the Change aims to inspire students across Canada to leverage technology to enact social change. We’re looking for creative and innovative solutions to existing problems, with the goal of coding a better tomorrow.`;
-  const ABOUT_THE_CHALLENGE_TITLE = (
-    <div className="flex flex-row flex-nowrap text-nowrap">
-      <h1 className="  text-3xl font-semibold">
-        About the
-        <span className=" italic text-fuzzy-peach"> Challenge</span>
-      </h1>
-      <Image
-        src={CHALLENGE_QUOTES_SVG}
-        width={20}
-        height={20}
-        alt="Challenge quotes"
-        className=" mb-4 ml-1 select-none"
-      />
-    </div>
-  );
-
-  const REQUIREMENTS_QUOTES_SVG = "/svgs/landingPage/requirements_quotes.svg";
-  const REQUIREMENTS_BLURB = `Requirements: Open to all Canadian students, at the university, college, or high school level. (Must be an accredited institution)`;
-  const REQUIREMENTS_TITLE = (
-    <div className="flex flex-row text-3xl font-semibold italic text-awesomer-purple">
-      <Image
-        src={REQUIREMENTS_QUOTES_SVG}
-        width={20}
-        height={20}
-        alt="Challenge quotes"
-        className=" mr-1 mt-2 select-none"
-      />
-      Requirements
-    </div>
-  );
-
-  const PRIZES_QUOTES_SVG = "/svgs/landingPage/prizes_quotes.svg";
-  const PRIZES_BLURB = `Prizes: 1st place - $5,000 CAD; 2nd place - $3,000; 3rd place - $2,000; All prizes will be split between students and the charities of their choice.`;
-  const PRIZES_TITLE = (
-    <div className="flex flex-row text-3xl font-semibold italic text-[#00AA88]">
-      Prizes
-      <Image
-        src={PRIZES_QUOTES_SVG}
-        width={20}
-        height={20}
-        alt="Challenge quotes"
-        className=" ml-1 mt-2 select-none"
-      />
-    </div>
-  );
-
   return (
     <div className="relative overflow-hidden">
       <div className=" pointer-events-none hidden select-none lg:block ">
@@ -154,28 +178,9 @@ export default function HackathonInformationContainer() {
           className="absolute top-[85rem] w-full"
         />
       </div>
-      <SectionContainer
-        bgColor="bg-awesomer-purple"
-        sectionImage={ABOUT_THE_CHALLENGE_IMAGE}
-        blurb={ABOUT_THE_CHALLENGE_BLURB}
-        title={ABOUT_THE_CHALLENGE_TITLE}
-        fontColor="text-white"
-      />
-      <SectionContainer
-        bgColor="bg-zinc-100"
-        sectionImage={REQUIREMENTS_IMAGE}
-        blurb={REQUIREMENTS_BLURB}
-        title={REQUIREMENTS_TITLE}
-        fontColor="text-black"
-        leftPosition
-      />
-      <SectionContainer
-        bgColor="bg-fuzzy-peach"
-        sectionImage={PRIZES_IMAGE}
-        blurb={PRIZES_BLURB}
-        title={PRIZES_TITLE}
-        fontColor="text-black"
-      />
+      {sectionInfo.map((section, index) => (
+        <SectionContainer key={index} {...section} />
+      ))}
     </div>
   );
 }

--- a/src/components/LandingPage/HeroCallToAction.tsx
+++ b/src/components/LandingPage/HeroCallToAction.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import Link from "next/link";
+
+import { useAuthenticator } from "@aws-amplify/ui-react";
+
+const LINK_STYLES =
+  " cursor-pointer opacity-95 pb-4 flex justify-start font-bold md:justify-center";
+export default function HeroCallToAction() {
+  const { authStatus } = useAuthenticator();
+  return (
+    <>
+      <div className={LINK_STYLES}>
+        <a
+          href={
+            authStatus === "authenticated"
+              ? "/participant/profile"
+              : "/register"
+          }
+        >
+          <div className=" rounded-2xl border-4 border-white bg-awesomer-purple px-6 py-2 text-sm text-white  hover:opacity-70 md:mb-0 md:px-6">
+            {authStatus === "authenticated"
+              ? "Go to Profile"
+              : "Join Hackathon"}
+          </div>
+        </a>
+      </div>
+      {authStatus !== "authenticated" && (
+        <div className={" flex gap-1 pb-4 font-bold opacity-95 "}>
+          {"Already registered? "}
+          <Link href="/login" className="text-awesomer-purple hover:opacity-70">
+            {" Sign in"}
+          </Link>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/LandingPage/HeroSection.tsx
+++ b/src/components/LandingPage/HeroSection.tsx
@@ -1,273 +1,35 @@
-"use client";
-
 import Image from "next/image";
-import { useEffect, useState } from "react";
 
 import { fetchContent } from "@/app/actions";
 import type { HackathonDetails } from "@/app/contentfulTypes";
-import CountdownTimer from "@/components/LandingPage/CountdownTimer";
-import { useAuthenticator } from "@aws-amplify/ui-react";
 
-const HERO_SECTION_CONTAINER =
-  "relative flex flex-col justify-between md:py-15 md:px-24 lg:px-40 ";
+import HackathonClock from "../HackathonClock";
+import HeroSectionTile from "./HeroSectionTile";
+import WindowContainer from "./WindowContainer";
+
 const HERO_SECTION_BACKGROUND =
   "/images/landingpage/HeroSection/hero_section_background.png";
-const HERO_HEADER_STYLE = {
-  textShadow: `
-		-2px -2px 0 #7055FD, 
-		2px -2px 0 #7055FD, 
-		-2px 2px 0 #7055FD, 
-		2px 2px 0 #7055FD,
-		-2px -2px 0 #7055FD,
-		2px -2px 0 #7055FD,
-		-2px 2px 0 #7055FD,
-		2px 2px 0 #7055FD
-	`,
-};
-const HERO_TILE_STYLES = "mx-10 mb-20 md:mb-0 lg:mt-10";
-const LINK_STYLES =
-  " cursor-pointer opacity-95 md:my-4 flex justify-start font-bold md:justify-center";
 
-const WEBPAGE_CONTAINER =
-  "hidden md:block lg:block rounded-t-md bg-[#00D3A9] opacity-95 ";
-
-const COUNTDOWN_CONTAINER = "mx-auto p-4";
-const TIMER_CONTAINER = "flex justify-center my-12";
-
-const HACKTIME_HEADER_STYLE = {
-  textShadow: `
-		-2px -2px 0 #fff, 
-		2px -2px 0 #fff, 
-		-2px 2px 0 #fff, 
-		2px 2px 0 #fff,
-		-2px -2px 0 #fff,
-		2px -2px 0 #fff,
-		-2px 2px 0 #fff,
-		2px 2px 0 #fff
-	`,
-};
-
-export const calculateDateDifference = (
-  targetDate: Date,
-  referenceDate = new Date(),
-): {
-  d: number;
-  h: number;
-  m: number;
-  s: number;
-} => {
-  const difference = targetDate.getTime() - referenceDate.getTime();
-
-  const d = Math.floor(difference / (1000 * 60 * 60 * 24));
-  const h = Math.floor((difference % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
-  const m = Math.floor((difference % (1000 * 60 * 60)) / (1000 * 60));
-  const s = Math.floor((difference % (1000 * 60)) / 1000);
-  return { d, h, m, s };
-};
-
-const HeroSectionTile = ({
-  hackathonDetails,
-}: {
-  hackathonDetails: Partial<HackathonDetails>;
-}) => {
-  const eventDate =
-    hackathonDetails?.fields?.eventDate || new Date().toISOString();
-  const { eventName, eventBlurb } = hackathonDetails?.fields || {};
-  const eventYear = eventDate ? new Date(eventDate).getFullYear() : 0;
-  const [hackathonTime, setHackathonTime] = useState(false);
-  const [timeRemaining, setTimeRemaining] = useState({
-    days: 0,
-    hours: 0,
-    minutes: 0,
-    seconds: 0,
-  });
-
-  useEffect(() => {
-    const updateCountdown = () => {
-      if (!isNaN(new Date(eventDate).getTime())) {
-        const { d, h, m, s } = calculateDateDifference(new Date(eventDate));
-        setTimeRemaining({ days: d, hours: h, minutes: m, seconds: s });
-
-        if (d + h + m + s <= 0) {
-          setHackathonTime(true);
-        }
-      }
-    };
-
-    const interval = setInterval(updateCountdown, 1000);
-    updateCountdown(); // Initialize with the current time difference
-
-    return () => clearInterval(interval);
-  }, [eventDate]);
-
-  const { authStatus } = useAuthenticator();
-
+export default async function HeroSection() {
+  const hackathonDetails = (
+    (await fetchContent("hackathonDetails")) as unknown as HackathonDetails[]
+  )[0];
   return (
-    <div className={HERO_TILE_STYLES}>
-      <div>
-        <h1
-          className="mt-16 flex-wrap text-5xl font-black text-[#FFFF] drop-shadow-lg md:text-center md:text-6xl"
-          style={HERO_HEADER_STYLE}
-        >
-          {eventName ? eventName : "Loading..."}
-          <span className="text-pastel-green">
-            {" "}
-            {eventYear ? eventYear : ""}
-          </span>
-        </h1>
-        <strong className="text-1xl my-4 flex flex-wrap justify-center text-awesomer-purple opacity-95  md:text-center md:text-xl lg:px-40">
-          {eventBlurb ? eventBlurb : ""}
-        </strong>
-      </div>
-
-      <div className={LINK_STYLES}>
-        <a
-          href={
-            authStatus === "authenticated"
-              ? "/participant/profile"
-              : "/register"
-          }
-        >
-          <div className="mb-4 rounded-2xl border-4 border-white bg-awesomer-purple px-6 py-2 text-sm text-white  hover:opacity-70 md:mb-0 md:px-6">
-            {authStatus === "authenticated"
-              ? "Go to Profile"
-              : "Join Hackathon"}
-          </div>
-        </a>
-      </div>
-
-      {authStatus !== "authenticated" && (
-        <div className={LINK_STYLES}>
-          <p className="my-2">
-            Already registered?{" "}
-            <a href="/login">
-              <span className="text-awesomer-purple hover:opacity-70">
-                Sign in
-              </span>
-            </a>
-          </p>
-        </div>
-      )}
-
-      <div className={WEBPAGE_CONTAINER}>
-        <div className="relative rounded-t-md border-t-[30px] border-white">
-          <Image
-            src={"/svgs/heroSection/window_control_buttons.svg"}
-            alt="check mark icon"
-            width={50}
-            height={50}
-            className="absolute left-0 top-0 -mt-5 ms-3"
-          />
-          <div className={COUNTDOWN_CONTAINER}>
-            <div className="m-2 h-96 rounded-3xl bg-pastel-green px-10 opacity-90 md:m-5">
-              {hackathonTime ? (
-                <h1
-                  className="flex-wrap pt-14 text-4xl font-black text-awesomer-purple drop-shadow-lg md:pt-20 md:text-center md:text-5xl lg:pt-32"
-                  style={HACKTIME_HEADER_STYLE}
-                >
-                  {eventName} {eventYear}
-                  <br />
-                  has begun!
-                </h1>
-              ) : (
-                <div>
-                  <h1 className="pt-10 text-center text-2xl font-bold text-awesomer-purple">
-                    {eventName ? <>{eventName} begins in ... </> : "Loading..."}
-                  </h1>
-                  <div className={TIMER_CONTAINER}>
-                    <div className="flex space-x-3">
-                      <CountdownTimer name="Days" value={timeRemaining.days} />
-                      <CountdownTimer
-                        name="Hours"
-                        value={timeRemaining.hours}
-                      />
-                      <CountdownTimer
-                        name="Minutes"
-                        value={timeRemaining.minutes}
-                      />
-                      <CountdownTimer
-                        name="Seconds"
-                        value={timeRemaining.seconds}
-                      />
-                    </div>
-                  </div>
-                </div>
-              )}
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-};
-
-export default function HeroSection() {
-  const [heroSectionDetails, setHeroSectionDetails] = useState<
-    Partial<HackathonDetails>
-  >({
-    fields: {
-      eventName: "",
-      eventBlurb: "",
-      eventDate: Date.now().toString(),
-      locationName: "",
-      locationImage: {
-        sys: {
-          id: "",
-          type: "Asset",
-          createdAt: "2024-08-27T05:39:52.573Z",
-          updatedAt: "2024-08-27T05:39:52.573Z",
-          environment: {
-            sys: {
-              id: "",
-              type: "Link",
-              linkType: "Environment",
-            },
-          },
-          revision: 1,
-          space: {
-            sys: {
-              id: "",
-              type: "Link",
-              linkType: "Space",
-            },
-          },
-        },
-        metadata: {
-          tags: [],
-        },
-        fields: {
-          file: {
-            url: "",
-            details: {
-              size: 0,
-              image: { width: 0, height: 0 },
-            },
-            fileName: "",
-            contentType: "",
-          },
-        },
-      },
-      prizeAmount: 0,
-    },
-  });
-  const getHackathonDetails = async () => {
-    const data = (await fetchContent(
-      "hackathonDetails",
-    )) as unknown as HackathonDetails[];
-    setHeroSectionDetails(data[0]);
-  };
-  useEffect(() => {
-    getHackathonDetails();
-  }, []);
-  return (
-    <div className={HERO_SECTION_CONTAINER}>
+    <div className="md:py-15 relative flex flex-col items-center justify-center md:px-8 lg:px-32 ">
       <Image
         src={HERO_SECTION_BACKGROUND}
         alt="Landing page background"
         fill={true}
         style={{ objectFit: "cover" }}
+        className="pointer-events-none"
       />
-      <HeroSectionTile hackathonDetails={heroSectionDetails} />
+      <HeroSectionTile hackathonDetails={hackathonDetails} />
+      <WindowContainer>
+        <HackathonClock
+          eventName={hackathonDetails.fields.eventName}
+          eventDate={new Date(hackathonDetails.fields.eventDate)}
+        />
+      </WindowContainer>
     </div>
   );
 }

--- a/src/components/LandingPage/HeroSectionTile.tsx
+++ b/src/components/LandingPage/HeroSectionTile.tsx
@@ -1,0 +1,43 @@
+import type { HackathonDetails } from "@/app/contentfulTypes";
+
+import HeroCallToAction from "./HeroCallToAction";
+
+const HERO_HEADER_STYLE = {
+  textShadow: `
+		-2px -2px 0 #7055FD, 
+		2px -2px 0 #7055FD, 
+		-2px 2px 0 #7055FD, 
+		2px 2px 0 #7055FD,
+		-2px -2px 0 #7055FD,
+		2px -2px 0 #7055FD,
+		-2px 2px 0 #7055FD,
+		2px 2px 0 #7055FD
+	`,
+};
+
+const HeroSectionTile = ({
+  hackathonDetails,
+}: {
+  hackathonDetails: HackathonDetails;
+}) => {
+  const eventDate = new Date(hackathonDetails.fields.eventDate);
+  const { eventBlurb, eventName } = hackathonDetails.fields;
+  const eventYear = eventDate.getFullYear();
+
+  return (
+    <div className={"flex flex-col px-4 pt-10 md:items-center md:px-0 "}>
+      <h1
+        className="flex-wrap text-5xl font-black text-pastel-green drop-shadow-lg md:text-center md:text-6xl"
+        style={HERO_HEADER_STYLE}
+      >
+        <span className="text-white">{eventName} </span> {" " + eventYear}
+      </h1>
+      <strong className="flex w-full max-w-7xl flex-wrap justify-center py-4 text-xl text-awesomer-purple opacity-95 md:text-center md:text-xl">
+        {eventBlurb}
+      </strong>
+      <HeroCallToAction />
+    </div>
+  );
+};
+
+export default HeroSectionTile;

--- a/src/components/LandingPage/WindowContainer.tsx
+++ b/src/components/LandingPage/WindowContainer.tsx
@@ -1,0 +1,26 @@
+import Image from "next/image";
+
+export default function WindowContainer({
+  children,
+}: {
+  children?: React.ReactNode;
+}) {
+  return (
+    <div
+      className={
+        "relative hidden min-w-[675px] flex-col items-center justify-center rounded-t-md border-t-[30px] border-white bg-[#00D3A9] py-8 opacity-95 md:flex  md:px-8 lg:w-11/12"
+      }
+    >
+      <Image
+        src={"/svgs/heroSection/window_control_buttons.svg"}
+        alt="check mark icon"
+        width={50}
+        height={50}
+        className="absolute left-0 top-0 -mt-5 ms-3"
+      />
+      <div className="flex min-h-96 w-full flex-col items-center rounded-3xl bg-pastel-green px-4 py-8 opacity-90 ">
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/utils/date-utils.tsx
+++ b/src/utils/date-utils.tsx
@@ -6,3 +6,34 @@ export const formatDate = (date: Date) => {
     minute: "numeric",
   });
 };
+
+export const calculateDateDifference = (
+  targetDate: Date,
+  referenceDate = new Date(),
+): {
+  days: number;
+  hours: number;
+  minutes: number;
+  seconds: number;
+} => {
+  const difference = targetDate.getTime() - referenceDate.getTime();
+  const days = Math.floor(difference / (1000 * 60 * 60 * 24));
+  const hours = Math.floor(
+    (difference % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60),
+  );
+  const minutes = Math.floor((difference % (1000 * 60 * 60)) / (1000 * 60));
+  const seconds = Math.floor((difference % (1000 * 60)) / 1000);
+  return { days, hours, minutes, seconds };
+};
+export const hackathonTimeRemaining = (
+  hackathonFinishTime: Date,
+  referenceDate = new Date(),
+): {
+  hours: number;
+  minutes: number;
+} => {
+  const difference = hackathonFinishTime.getTime() - referenceDate.getTime();
+  const hours = Math.floor(difference / (1000 * 60 * 60));
+  const minutes = Math.floor((difference % (1000 * 60 * 60)) / (1000 * 60));
+  return { hours, minutes };
+};


### PR DESCRIPTION
Ipad mini screen size looks good now. No text cut out. Also optimized the timer component to prevent Cumulative Layout Shift (CLS) which was causing a visual headache on smaller screen devices.

![image](https://github.com/user-attachments/assets/8331941a-56a4-4bf8-ac4a-4b279a4c4872)

Also updated the message when Timer expires in the participant Dashboard
![image](https://github.com/user-attachments/assets/e4bd9d5f-df99-43c3-8c4e-faad587636fd)
